### PR TITLE
Changed epel repo installation 

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM rhel7
 
-RUN yum install epel-release
+RUN yum install epel-release -y
 
 RUN yum install redis hostname -y ; yum clean all
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM rhel7
 
-RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+RUN yum install epel-release
 
 RUN yum install redis hostname -y ; yum clean all
 


### PR DESCRIPTION
The epel rpm url casted is not reachable anymore. Is better use epel-release package from basic rhel repository.